### PR TITLE
Fix the issue where pasted links retain the original filename when the original filename contains non-URL-safe characters.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -67,8 +67,10 @@ export default class HashPastedImagePlugin extends Plugin {
 
 		const cursor = editor.getCursor();
 		const line = editor.getLine(cursor.line);
-		const replacedLine = line.replace(originName, newName);
-
+		let replacedLine = line.replace(originName, newName);
+    	if(line == replacedLine){
+        	replacedLine = line.replace(encodeURI(originName), newName);
+    	}
 		editor.transaction({
 			changes: [
 				{


### PR DESCRIPTION
Phenomenon: In Obsidian v1.8.9 on both Linux and Windows, when pasting an image from an external source, the image is successfully added to the vault and renamed. However, the markdown link for the pasted image retains the original filename.
After investigation, the issue was found in `renameFile()`. When attempting to overwrite the original file link, Obsidian may URL-encode the file path, causing the `replace` operation to fail in locating and replacing the original filename.